### PR TITLE
[iOS] 캘린더 컬렉션뷰에 오늘 이후의 날짜값 데이터 바인딩 

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		30B2E9242473F2C6002FB866 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B2E9232473F2C6002FB866 /* SearchViewController.swift */; };
 		30B2E9262473F367002FB866 /* AccommodationSearchCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B2E9252473F367002FB866 /* AccommodationSearchCollectionViewDataSource.swift */; };
 		30B2E928247401EB002FB866 /* SearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B2E927247401EB002FB866 /* SearchTextField.swift */; };
+		30D248DE247694C3002F64F2 /* CalendarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D248DC247694C3002F64F2 /* CalendarHeaderView.swift */; };
 		7872575924750C520050DB66 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7872575824750C520050DB66 /* CalendarViewController.swift */; };
 		787257642475132A0050DB66 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787257632475132A0050DB66 /* DateManager.swift */; };
 		78725766247525270050DB66 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78725765247525270050DB66 /* CalendarCollectionViewCell.swift */; };
@@ -33,6 +34,7 @@
 		30B2E9232473F2C6002FB866 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		30B2E9252473F367002FB866 /* AccommodationSearchCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccommodationSearchCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		30B2E927247401EB002FB866 /* SearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextField.swift; sourceTree = "<group>"; };
+		30D248DC247694C3002F64F2 /* CalendarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHeaderView.swift; sourceTree = "<group>"; };
 		4012801DAD21A7AE478D9312 /* Pods-Airbnb.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Airbnb.debug.xcconfig"; path = "Target Support Files/Pods-Airbnb/Pods-Airbnb.debug.xcconfig"; sourceTree = "<group>"; };
 		7872575824750C520050DB66 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		787257632475132A0050DB66 /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 			isa = PBXGroup;
 			children = (
 				301FD859247552F000F95C72 /* CircleView.swift */,
+				30D248DC247694C3002F64F2 /* CalendarHeaderView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -329,6 +332,7 @@
 				30B2E928247401EB002FB866 /* SearchTextField.swift in Sources */,
 				78802ADD2473A7E200A901E2 /* FilterButton.swift in Sources */,
 				301FD85A247552F000F95C72 /* CircleView.swift in Sources */,
+				30D248DE247694C3002F64F2 /* CalendarHeaderView.swift in Sources */,
 				787257642475132A0050DB66 /* DateManager.swift in Sources */,
 				78802ADF2473ABD500A901E2 /* AccommodationSearchCollectionView.swift in Sources */,
 				78802AE42473BF1200A901E2 /* AccommodationSearchCollectionViewCell.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -232,21 +232,26 @@
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
-                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="CalendarHeader" id="aLH-4J-OQ3">
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="CalendarHeader" id="aLH-4J-OQ3" customClass="CalendarHeaderView" customModule="Airbnb" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May 2020" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YOE-Zd-iLa">
-                                            <rect key="frame" x="16" y="15" width="82" height="20.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eL3-es-HTW">
+                                            <rect key="frame" x="16" y="8" width="390" height="34"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="YOE-Zd-iLa" firstAttribute="leading" secondItem="aLH-4J-OQ3" secondAttribute="leadingMargin" constant="8" id="JKn-da-pIg"/>
-                                        <constraint firstItem="YOE-Zd-iLa" firstAttribute="centerY" secondItem="aLH-4J-OQ3" secondAttribute="centerY" id="rD1-60-3Ef"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="eL3-es-HTW" secondAttribute="bottom" id="OvV-Wq-9A2"/>
+                                        <constraint firstItem="eL3-es-HTW" firstAttribute="top" secondItem="aLH-4J-OQ3" secondAttribute="topMargin" id="Zd3-bm-NQw"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="eL3-es-HTW" secondAttribute="trailing" id="fSo-vK-5Ox"/>
+                                        <constraint firstItem="eL3-es-HTW" firstAttribute="leading" secondItem="aLH-4J-OQ3" secondAttribute="leadingMargin" constant="8" id="fuQ-WU-h0U"/>
                                     </constraints>
+                                    <connections>
+                                        <outlet property="yearMonthLabel" destination="eL3-es-HTW" id="sXE-E5-95v"/>
+                                    </connections>
                                 </collectionReusableView>
                             </collectionView>
                         </subviews>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -186,7 +186,7 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="8ac-IH-Z8X">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="8ac-IH-Z8X">
                                 <rect key="frame" x="0.0" y="212" width="414" height="414"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>

--- a/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
+++ b/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
@@ -13,14 +13,15 @@ struct DateManager {
     private let calendar = Calendar.current
     private var months: [Int] = []
     
-    func firstWeekday() -> Int {
-        let component = calendar.dateComponents([.year, .month, .weekday], from: Date())
+    func firstWeekday(month: Int) -> Int {
+        var component = calendar.dateComponents([.year, .month, .weekday], from: Date())
+        component.month! += month
         let startOfMonth = calendar.date(from: component)
         let firstWeekday = calendar.dateComponents([.year, .month, .weekday], from: startOfMonth!)
         return firstWeekday.weekday! - 1
     }
     
-    mutating func getCountOfMonths() -> [Int] {
+    mutating func countOfMonths() -> [Int] {
         let thisMonth = calendar.dateComponents([.month], from: Date())
         for month in thisMonth.month!...12 {
             months.append(month)
@@ -28,16 +29,15 @@ struct DateManager {
         return months
     }
     
-    func getCountOfDays(year: Int, month: Int) -> Int {
+    mutating func countOfDays(year: Int, month: Int) -> Int {
         let dateComponents = DateComponents(year: year, month: month)
         let calendar = Calendar.current
         let date = calendar.date(from: dateComponents)!
-
         let range = calendar.range(of: .day, in: .month, for: date)!
         return range.count
     }
     
-    func getMonth(index: Int) -> Int {
+    func month(index: Int) -> Int {
         return months[index]
     }
 }

--- a/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
+++ b/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
@@ -10,15 +10,34 @@ import Foundation
 
 struct DateManager {
     
-    let months: [String] = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+    private let calendar = Calendar.current
+    private var months: [Int] = []
     
     func firstWeekday() -> Int {
-        let calendar = NSCalendar.current
-        let now = Date()
-        let component = calendar.dateComponents([.year, .month, .weekday], from: now)
+        let component = calendar.dateComponents([.year, .month, .weekday], from: Date())
         let startOfMonth = calendar.date(from: component)
         let firstWeekday = calendar.dateComponents([.year, .month, .weekday], from: startOfMonth!)
         return firstWeekday.weekday! - 1
     }
     
+    mutating func getCountOfMonths() -> [Int] {
+        let thisMonth = calendar.dateComponents([.month], from: Date())
+        for month in thisMonth.month!...12 {
+            months.append(month)
+        }
+        return months
+    }
+    
+    func getCountOfDays(year: Int, month: Int) -> Int {
+        let dateComponents = DateComponents(year: year, month: month)
+        let calendar = Calendar.current
+        let date = calendar.date(from: dateComponents)!
+
+        let range = calendar.range(of: .day, in: .month, for: date)!
+        return range.count
+    }
+    
+    func getMonth(index: Int) -> Int {
+        return months[index]
+    }
 }

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -47,7 +47,7 @@ extension CalendarViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "CalendarHeader", for: indexPath) as! CalendarHeaderView
         headerView.set("\(dateManager.getMonth(index: indexPath.section))월")
-        return headerViewa
+        return headerView
     }
     
 }

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -11,8 +11,8 @@ import UIKit
 class CalendarViewController: UIViewController {
     @IBOutlet weak var calendarCollectionView: UICollectionView!
     
-    private let dateManager = DateManager()
-
+    private var dateManager = DateManager()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configure()
@@ -34,14 +34,22 @@ extension CalendarViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CalendarCell", for: indexPath) as! CalendarCollectionViewCell
         if dateManager.firstWeekday() == indexPath.item {
             cell.configure(date: 1)
+        } else if indexPath.item > dateManager.firstWeekday() {
+            cell.configure(date: 3)
         }
         return cell
     }
     
-    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "CalendarHeader", for: indexPath)
-        return headerView
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return dateManager.getCountOfMonths().count
     }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "CalendarHeader", for: indexPath) as! CalendarHeaderView
+        headerView.set("\(dateManager.getMonth(index: indexPath.section))월")
+        return headerViewa
+    }
+    
 }
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -27,29 +27,30 @@ class CalendarViewController: UIViewController {
 extension CalendarViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 35
+        return 42
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let weekday = dateManager.firstWeekday(month: indexPath.section)
+        let thisMonth = dateManager.month(index: indexPath.section)
+        let date = indexPath.item - weekday + 1
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CalendarCell", for: indexPath) as! CalendarCollectionViewCell
-        if dateManager.firstWeekday() == indexPath.item {
-            cell.configure(date: 1)
-        } else if indexPath.item > dateManager.firstWeekday() {
-            cell.configure(date: 3)
+        
+        if 1...dateManager.countOfDays(year: 2020, month: thisMonth) ~= date {
+            cell.configure(date: date)
         }
         return cell
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return dateManager.getCountOfMonths().count
+        return dateManager.countOfMonths().count
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "CalendarHeader", for: indexPath) as! CalendarHeaderView
-        headerView.set("\(dateManager.getMonth(index: indexPath.section))월")
+        headerView.set("2020년 \(dateManager.month(index: indexPath.section))월")
         return headerView
     }
-    
 }
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {

--- a/iOS/Airbnb/Airbnb/Views/CalendarView/CalendarCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Views/CalendarView/CalendarCollectionViewCell.swift
@@ -21,6 +21,11 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        dateLabel.text = ""
+    }
+    
     func configure(date: Int) {
         dateLabel.text = "\(date)"
     }

--- a/iOS/Airbnb/Airbnb/Views/Components/CalendarHeaderView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/CalendarHeaderView.swift
@@ -1,0 +1,21 @@
+//
+//  CalendarHeaderView.swift
+//  Airbnb
+//
+//  Created by delma on 2020/05/21.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import UIKit
+
+class CalendarHeaderView: UICollectionReusableView {
+
+    @IBOutlet var yearMonthLabel: UILabel!
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func set(_ text: String) {
+        yearMonthLabel.text = text
+    }
+}

--- a/iOS/Airbnb/Airbnb/Views/Components/CircleView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/CircleView.swift
@@ -21,7 +21,7 @@ class CircleView: UIView {
     }
     
     private func configure() {
-        self.layer.cornerRadius = self.bounds.size.height / 2
+        self.layer.cornerRadius = self.frame.height / 2 + self.frame.height / 10
         self.clipsToBounds = true
         self.backgroundColor = .black
         self.alpha = 0.0


### PR DESCRIPTION
### 섹션과 거기에 포함되는 셀들을 분리하여 섹션에는 연도와 월을, 셀에는 해당 월의 날짜들을 넣어주었음.

데이터 매니저에서는 
- firstWeekday(month:)에서 입력받은 month를 기반으로 해당 월의 첫 시작 요일을 리턴함.
- 첫 시작 요일을 기반으로 countOfDays(year:month:)가 리턴하는 해당 월의 카운트만큼 셀에 바인딩함.
- countOfMonths() 가 리턴하는 배열로 섹션에 데이터 바인딩함. 

![calendar](https://user-images.githubusercontent.com/40784518/82565641-b7027980-9bb5-11ea-8a78-eaff1a0990dd.gif)
