### PR TITLE
[iOS] 선택된 체크인-아웃 날짜를 헤더와 숙소 찾기 화면에 반영 

### DIFF
--- a/iOS/Airbnb/Airbnb/Assets.xcassets/MainColor.colorset/Contents.json
+++ b/iOS/Airbnb/Airbnb/Assets.xcassets/MainColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.485",
+          "green" : "0.501",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -39,7 +39,7 @@
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                 <state key="normal" title="날짜"/>
                                 <connections>
-                                    <action selector="displayPopup:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gHI-fI-2VC"/>
+                                    <action selector="showCalendarViewController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="t5S-fP-OCy"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행하시는 날짜와 인원을 입력해주세요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iJz-N8-4Vl">
@@ -116,11 +116,8 @@
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" selectedImage="magnifyingglass" id="VwQ-nf-25J"/>
                     <connections>
                         <outlet property="accommodationSearchCollectionView" destination="Q4f-ws-TDw" id="fwg-7X-aVd"/>
-                        <outlet property="dateFilterButton" destination="7aL-2j-hug" id="nOp-rZ-2fP"/>
                         <outlet property="filteringDescriptionLabel" destination="iJz-N8-4Vl" id="uhC-qX-nhJ"/>
                         <outlet property="floatingButton" destination="bQB-yv-dul" id="dMf-gK-vlR"/>
-                        <outlet property="guestFilterButton" destination="ldT-Of-ujo" id="R3a-2N-ash"/>
-                        <outlet property="priceFilterButton" destination="OIr-cS-Znl" id="9XJ-ET-SV1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -17,36 +17,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ipc-gY-hMO" customClass="SearchTextField" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="32" y="52" width="350" height="34"/>
+                                <rect key="frame" x="32" y="66" width="350" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OIr-cS-Znl" customClass="FilterButton" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="108" y="94" width="30" height="30"/>
+                                <rect key="frame" x="116" y="116" width="30" height="30"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                 <state key="normal" title="가격"/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ldT-Of-ujo" customClass="FilterButton" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="70" y="94" width="30" height="30"/>
+                                <rect key="frame" x="74" y="116" width="30" height="30"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                 <state key="normal" title="인원"/>
                                 <connections>
                                     <action selector="displayPopup:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hsJ-7E-Ojk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7aL-2j-hug" customClass="FilterButton" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="32" y="94" width="30" height="30"/>
+                                <rect key="frame" x="32" y="116" width="30" height="30"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                 <state key="normal" title="날짜"/>
                                 <connections>
                                     <action selector="displayPopup:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gHI-fI-2VC"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iJz-N8-4Vl">
-                                <rect key="frame" x="186" y="136" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행하시는 날짜와 인원을 입력해주세요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iJz-N8-4Vl">
+                                <rect key="frame" x="80.5" y="170" width="253" height="19.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Q4f-ws-TDw" customClass="AccommodationSearchCollectionView" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="180" width="414" height="633"/>
+                                <rect key="frame" x="0.0" y="213.5" width="414" height="599.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Mq6-ga-34U">
                                     <size key="itemSize" width="398" height="251"/>
@@ -66,16 +69,16 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bQB-yv-dul" customClass="Floaty" customModule="Floaty">
-                                <rect key="frame" x="356" y="755" width="50" height="50"/>
+                            <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bQB-yv-dul" customClass="Floaty" customModule="Floaty">
+                                <rect key="frame" x="343" y="745" width="60" height="60"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <color key="tintColor" red="0.3406607385" green="0.75541996320000004" blue="0.73081690749999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="50" id="csV-27-c0P"/>
-                                    <constraint firstAttribute="height" constant="50" id="iNz-DJ-EyT"/>
+                                    <constraint firstAttribute="width" constant="60" id="csV-27-c0P"/>
+                                    <constraint firstAttribute="height" constant="60" id="iNz-DJ-EyT"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="image" keyPath="buttonImage" value="map" catalog="system"/>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="buttonImage" value="map.fill" catalog="system"/>
                                     <userDefinedRuntimeAttribute type="color" keyPath="itemButtonColor">
                                         <color key="value" red="0.3406607385" green="0.75541996320000004" blue="0.73081690749999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
@@ -90,22 +93,22 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="ldT-Of-ujo" firstAttribute="centerY" secondItem="7aL-2j-hug" secondAttribute="centerY" id="18g-Kv-YuS"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="ipc-gY-hMO" secondAttribute="trailing" constant="32" id="2yT-8n-NaL"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="bQB-yv-dul" secondAttribute="bottom" constant="8" id="7N0-Zc-VwK"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="bQB-yv-dul" secondAttribute="bottom" constant="12" id="7N0-Zc-VwK"/>
                             <constraint firstItem="ipc-gY-hMO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="32" id="7nY-3z-LnU"/>
-                            <constraint firstItem="ldT-Of-ujo" firstAttribute="top" secondItem="ipc-gY-hMO" secondAttribute="bottom" constant="8" id="96P-EJ-voh"/>
-                            <constraint firstItem="ldT-Of-ujo" firstAttribute="leading" secondItem="7aL-2j-hug" secondAttribute="trailing" constant="8" id="Cyf-kb-Tc8"/>
-                            <constraint firstItem="7aL-2j-hug" firstAttribute="top" secondItem="ipc-gY-hMO" secondAttribute="bottom" constant="8" id="Ksx-I6-lf8"/>
+                            <constraint firstItem="ldT-Of-ujo" firstAttribute="leading" secondItem="7aL-2j-hug" secondAttribute="trailing" constant="12" id="Cyf-kb-Tc8"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Q4f-ws-TDw" secondAttribute="trailing" id="Xk6-fo-Dz8"/>
+                            <constraint firstItem="iJz-N8-4Vl" firstAttribute="top" secondItem="OIr-cS-Znl" secondAttribute="bottom" constant="24" id="ZTX-M7-bET"/>
                             <constraint firstItem="7aL-2j-hug" firstAttribute="leading" secondItem="ipc-gY-hMO" secondAttribute="leading" id="ZoI-wG-pP1"/>
-                            <constraint firstItem="OIr-cS-Znl" firstAttribute="top" secondItem="ipc-gY-hMO" secondAttribute="bottom" constant="8" id="eQv-aP-rUm"/>
-                            <constraint firstItem="OIr-cS-Znl" firstAttribute="leading" secondItem="ldT-Of-ujo" secondAttribute="trailing" constant="8" id="eRW-o6-qdD"/>
+                            <constraint firstItem="7aL-2j-hug" firstAttribute="top" secondItem="ipc-gY-hMO" secondAttribute="bottom" constant="16" id="a1C-VD-RGo"/>
+                            <constraint firstItem="OIr-cS-Znl" firstAttribute="leading" secondItem="ldT-Of-ujo" secondAttribute="trailing" constant="12" id="eRW-o6-qdD"/>
                             <constraint firstItem="Q4f-ws-TDw" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="euT-Cg-PlQ"/>
                             <constraint firstItem="iJz-N8-4Vl" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="gZL-8o-hst"/>
-                            <constraint firstItem="ipc-gY-hMO" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lYg-on-H3L"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bQB-yv-dul" secondAttribute="trailing" constant="8" id="m4Y-Ve-M6q"/>
-                            <constraint firstItem="Q4f-ws-TDw" firstAttribute="top" secondItem="iJz-N8-4Vl" secondAttribute="bottom" constant="23" id="rXq-f8-5iX"/>
-                            <constraint firstItem="iJz-N8-4Vl" firstAttribute="top" secondItem="ipc-gY-hMO" secondAttribute="bottom" constant="50" id="vVU-A2-osC"/>
+                            <constraint firstItem="ipc-gY-hMO" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="22" id="lYg-on-H3L"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bQB-yv-dul" secondAttribute="trailing" constant="12" id="m4Y-Ve-M6q"/>
+                            <constraint firstItem="OIr-cS-Znl" firstAttribute="centerY" secondItem="ldT-Of-ujo" secondAttribute="centerY" id="pGw-BS-hgd"/>
+                            <constraint firstItem="Q4f-ws-TDw" firstAttribute="top" secondItem="iJz-N8-4Vl" secondAttribute="bottom" constant="24" id="rXq-f8-5iX"/>
                             <constraint firstItem="Q4f-ws-TDw" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="wfB-fm-JS2"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -163,54 +166,54 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="7HO-nV-QEN">
-                                        <rect key="frame" x="0.0" y="76" width="373" height="16"/>
+                                        <rect key="frame" x="0.0" y="76" width="373" height="19.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NjV-cM-hex">
-                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Bc-6g-otZ">
-                                                <rect key="frame" x="53.5" y="0.0" width="53" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="53.5" y="0.0" width="53" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="화" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nER-90-dlT">
-                                                <rect key="frame" x="106.5" y="0.0" width="53.5" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="106.5" y="0.0" width="53.5" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wcw-ej-eoA">
-                                                <rect key="frame" x="160" y="0.0" width="53" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="160" y="0.0" width="53" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n2s-1a-5lg">
-                                                <rect key="frame" x="213" y="0.0" width="53.5" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="213" y="0.0" width="53.5" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="금" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1H-rq-Omn">
-                                                <rect key="frame" x="266.5" y="0.0" width="53" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="266.5" y="0.0" width="53" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YfA-hl-mQp">
-                                                <rect key="frame" x="319.5" y="0.0" width="53.5" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                                <rect key="frame" x="319.5" y="0.0" width="53.5" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="8ac-IH-Z8X">
-                                        <rect key="frame" x="0.0" y="108" width="373" height="372.5"/>
+                                        <rect key="frame" x="0.0" y="111.5" width="373" height="372.5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="8ac-IH-Z8X" secondAttribute="height" id="29L-vr-uxg"/>
@@ -278,8 +281,8 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SPF-OK-GfU">
-                                                    <rect key="frame" x="16" y="15" width="42" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <rect key="frame" x="16" y="15" width="43.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -538,7 +541,7 @@
         <image name="heart.fill" catalog="system" width="128" height="109"/>
         <image name="logo" width="81.666664123535156" height="90"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
-        <image name="map" catalog="system" width="128" height="113"/>
+        <image name="map.fill" catalog="system" width="128" height="113"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
     </resources>
 </document>

--- a/iOS/Airbnb/Airbnb/Delegates/SendDataDelegate.swift
+++ b/iOS/Airbnb/Airbnb/Delegates/SendDataDelegate.swift
@@ -1,0 +1,9 @@
+//
+//  SendDelegate.swift
+//  Airbnb
+//
+//  Created by delma on 2020/05/30.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Airbnb/Airbnb/Delegates/SendDataDelegate.swift
+++ b/iOS/Airbnb/Airbnb/Delegates/SendDataDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  SendDelegate.swift
+//  SendDataDelegate.swift
 //  Airbnb
 //
 //  Created by delma on 2020/05/30.
@@ -7,3 +7,7 @@
 //
 
 import Foundation
+
+protocol SendDataDelegate {
+    func send(text: String)
+}

--- a/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
+++ b/iOS/Airbnb/Airbnb/Utilities/Date/DateManager.swift
@@ -33,7 +33,10 @@ struct DateManager {
     }
     
     mutating func countOfDays(year: Int, month: Int) -> Int {
-        let date = calendar.date(from: nowComponents)!
+        var component = nowComponents
+        component.year! = year
+        component.month! = month
+        let date = calendar.date(from: component)!
         let range = calendar.range(of: .day, in: .month, for: date)!
         return range.count
     }

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -15,11 +15,17 @@ final class CalendarViewController: UIViewController {
     @IBOutlet weak var calendarCollectionView: UICollectionView!
     @IBOutlet weak var footerView: PopupFooterView!
 
+    var delegate: SendDataDelegate?
     private var dateManager = DateManager()
     private var chooseDays: [IndexPath] = [] {
         didSet {
-            chooseDays.count == 1 ? changeCheckedLabel(calculator(chooseDays[0])) : changeCheckedLabel("체크인 ― 체크아웃")
-            chooseDays.count == 2 ? changeCheckedLabel("\(calculator(chooseDays[0])) ― \(calculator(chooseDays[1]))") : nil
+            if chooseDays.count == 2 {
+                changeCheckedLabel("\(calculator(chooseDays[0])) ― \(calculator(chooseDays[1]))")
+                footerView.enableCompleteButton()
+            } else {
+                chooseDays.count == 1 ? changeCheckedLabel(calculator(chooseDays[0])) : changeCheckedLabel("체크인 ― 체크아웃")
+                footerView.disableCompleteButton()
+            }
         }
     }
     private var periodDays: [IndexPath] = []
@@ -55,6 +61,9 @@ final class CalendarViewController: UIViewController {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(reset),
                                                name: .reset, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(completeSelection),
+                                               name: .complete, object: nil)
     }
 
     @objc private func close() {
@@ -65,6 +74,12 @@ final class CalendarViewController: UIViewController {
         chooseDays.removeAll()
         periodDays.removeAll()
         calendarCollectionView.reloadData()
+    }
+    
+    @objc private func completeSelection() {
+        dismiss(animated: true) {
+            self.delegate?.send(text: "\(self.calculator(self.chooseDays[0])) ― \(self.calculator(self.chooseDays[1]))")
+        }
     }
     
     private func changeCheckedLabel(_ text: String) {

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -47,10 +47,19 @@ final class CalendarViewController: UIViewController {
                                                selector: #selector(close),
                                                name: NotificationName.closeButtonDidTouch,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(reset),
+                                               name: .reset, object: nil)
     }
 
     @objc private func close() {
         dismiss(animated: true, completion: nil)
+    }
+    
+    @objc private func reset() {
+        chooseDays.removeAll()
+        periodDays.removeAll()
+        calendarCollectionView.reloadData()
     }
 }
 
@@ -248,5 +257,12 @@ extension CalendarViewController: UICollectionViewDelegate {
     private func changeBackgroundPeriodCells(_ collectionView: UICollectionView, indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CalendarCollectionViewCell else { return }
         cell.changeBackground()
+    }
+    
+    private func calculator(_ indexPath: IndexPath) -> String {
+        let thisMonth = dateManager.thisMonth(indexPath.section)
+        let month = indexPath.section + thisMonth
+        let date = indexPath.item - dateManager.firstWeekday(thisMonth: thisMonth)
+        return "\(month)월 \(date)일"
     }
 }

--- a/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/CalendarViewController.swift
@@ -16,7 +16,12 @@ final class CalendarViewController: UIViewController {
     @IBOutlet weak var footerView: PopupFooterView!
 
     private var dateManager = DateManager()
-    private var chooseDays: [IndexPath] = []
+    private var chooseDays: [IndexPath] = [] {
+        didSet {
+            chooseDays.count == 1 ? changeCheckedLabel(calculator(chooseDays[0])) : changeCheckedLabel("체크인 ― 체크아웃")
+            chooseDays.count == 2 ? changeCheckedLabel("\(calculator(chooseDays[0])) ― \(calculator(chooseDays[1]))") : nil
+        }
+    }
     private var periodDays: [IndexPath] = []
 
     override func viewDidLoad() {
@@ -39,7 +44,7 @@ final class CalendarViewController: UIViewController {
     private func configureView() {
         contentView.layer.cornerRadius = 12.0
         contentView.layer.masksToBounds = true
-        headerView.titleLabel.text = "체크인 ― 체크아웃"
+        headerView.changeTitle("체크인 ― 체크아웃")
     }
 
     private func registerNotification() {
@@ -60,6 +65,10 @@ final class CalendarViewController: UIViewController {
         chooseDays.removeAll()
         periodDays.removeAll()
         calendarCollectionView.reloadData()
+    }
+    
+    private func changeCheckedLabel(_ text: String) {
+        headerView.changeTitle(text)
     }
 }
 
@@ -261,8 +270,7 @@ extension CalendarViewController: UICollectionViewDelegate {
     
     private func calculator(_ indexPath: IndexPath) -> String {
         let thisMonth = dateManager.thisMonth(indexPath.section)
-        let month = indexPath.section + thisMonth
-        let date = indexPath.item - dateManager.firstWeekday(thisMonth: thisMonth)
-        return "\(month)월 \(date)일"
+        let date = indexPath.item - dateManager.firstWeekday(thisMonth: thisMonth) + 1
+        return "\(thisMonth)월 \(date)일"
     }
 }

--- a/iOS/Airbnb/Airbnb/ViewControllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/SearchViewController.swift
@@ -11,9 +11,6 @@ import Floaty
 
 class SearchViewController: UIViewController {
     
-    @IBOutlet weak var dateFilterButton: FilterButton!
-    @IBOutlet weak var guestFilterButton: FilterButton!
-    @IBOutlet weak var priceFilterButton: FilterButton!
     @IBOutlet weak var filteringDescriptionLabel: SearchTextField!
     @IBOutlet weak var accommodationSearchCollectionView: AccommodationSearchCollectionView!
     @IBOutlet weak var floatingButton: Floaty!
@@ -39,6 +36,18 @@ class SearchViewController: UIViewController {
         accommodationSearchCollectionView.showsVerticalScrollIndicator = false
     }
     
+    @IBAction func showCalendarViewController(_ sender: Any) {
+        guard let calendarViewController = storyboard?.instantiateViewController(withIdentifier: "CalendarViewController") as? CalendarViewController else { return }
+        calendarViewController.delegate = self
+        show(calendarViewController)
+    }
+    
+    private func show(_ viewController: UIViewController) {
+        viewController.modalPresentationStyle = .overCurrentContext
+        viewController.modalTransitionStyle = .crossDissolve
+        present(viewController, animated: true, completion: nil)
+    }
+    
     @IBAction func displayPopup(_ sender: UIButton) {
         guard let title = sender.currentTitle else { return }
         guard let viewController = storyboard?.instantiateViewController(withIdentifier: identifiers[title]!) else { return }
@@ -57,5 +66,15 @@ class SearchViewController: UIViewController {
                 }
             })
         }
+    }
+    
+    func changeFilteringDescription(_ text: String) {
+        filteringDescriptionLabel.text = text
+    }
+}
+
+extension SearchViewController: SendDataDelegate {
+    func send(text: String) {
+        changeFilteringDescription(text)
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/Components/CircleView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/CircleView.swift
@@ -21,7 +21,7 @@ class CircleView: UIView {
     }
     
     private func configure() {
-        self.layer.cornerRadius = self.frame.height / 2 + self.frame.height / 10
+        self.layer.cornerRadius = self.frame.height / 2
         self.clipsToBounds = true
         self.backgroundColor = .black
         self.alpha = 0.0

--- a/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.swift
@@ -32,4 +32,11 @@ class PopupFooterView: UIView {
         completeButton.layer.masksToBounds = true
     }
 
+    @IBAction func reset(_ sender: Any) {
+        NotificationCenter.default.post(name: .reset, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let reset = Notification.Name("reset")
 }

--- a/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.swift
@@ -30,13 +30,29 @@ class PopupFooterView: UIView {
         contentView.frame = self.bounds
         completeButton.layer.cornerRadius = 5.0
         completeButton.layer.masksToBounds = true
+        completeButton.isEnabled = false
     }
 
+    @IBAction func complete(_ sender: Any) {
+        NotificationCenter.default.post(name: .complete, object: nil)
+    }
+    
     @IBAction func reset(_ sender: Any) {
         NotificationCenter.default.post(name: .reset, object: nil)
+    }
+    
+    func enableCompleteButton() {
+        completeButton.isEnabled = true
+        completeButton.backgroundColor = UIColor(named: "MainColor")
+    }
+    
+    func disableCompleteButton() {
+        completeButton.isEnabled = false
+        completeButton.backgroundColor = .black
     }
 }
 
 extension Notification.Name {
     static let reset = Notification.Name("reset")
+    static let complete = Notification.Name("complete")
 }

--- a/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.xib
+++ b/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,6 +25,9 @@
                     <state key="normal" title="초기화">
                         <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </state>
+                    <connections>
+                        <action selector="reset:" destination="-1" eventType="touchUpInside" id="5vl-T8-ajY"/>
+                    </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PJ3-jB-GjI">
                     <rect key="frame" x="336" y="53" width="66" height="38"/>

--- a/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.xib
+++ b/iOS/Airbnb/Airbnb/Views/Components/PopupFooterView.xib
@@ -37,6 +37,9 @@
                     <state key="normal" title="완료">
                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </state>
+                    <connections>
+                        <action selector="complete:" destination="-1" eventType="touchUpInside" id="wJN-Qo-1ec"/>
+                    </connections>
                 </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/iOS/Airbnb/Airbnb/Views/Components/PopupHeaderView.swift
+++ b/iOS/Airbnb/Airbnb/Views/Components/PopupHeaderView.swift
@@ -28,10 +28,14 @@ class PopupHeaderView: UIView {
         configure()
     }
     
-    func configure() {
+     private func configure() {
         Bundle.main.loadNibNamed("PopupHeaderView", owner: self, options: nil)
         addSubview(contentView)
         contentView.frame = self.bounds
+    }
+    
+    func changeTitle(_ text: String) {
+        titleLabel.text = text
     }
 
 }

--- a/iOS/Airbnb/Airbnb/Views/SearchView/AccommodationSearchCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Views/SearchView/AccommodationSearchCollectionViewCell.swift
@@ -23,6 +23,18 @@ class AccommodationSearchCollectionViewCell: UICollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         scrollView.delegate = self
+        configure()
+    }
+    
+    private func configure() {
+        self.contentView.layer.cornerRadius = 10.0
+        self.contentView.layer.masksToBounds = true
+        
+        self.layer.shadowColor = UIColor.black.cgColor
+        self.layer.shadowOffset = CGSize(width: 0, height: 2.0)
+        self.layer.shadowRadius = 2.0
+        self.layer.shadowOpacity = 0.3
+        self.layer.masksToBounds = false
     }
     
     private func add(images: [UIImage]) {

--- a/iOS/Airbnb/Airbnb/Views/SearchView/FilterButton.swift
+++ b/iOS/Airbnb/Airbnb/Views/SearchView/FilterButton.swift
@@ -24,6 +24,7 @@ class FilterButton: UIButton {
     
     private func configure() {
         self.setTitleColor(.lightGray, for: .normal)
+        self.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         self.layer.borderWidth = 1.0
         self.layer.borderColor = UIColor.lightGray.cgColor
         self.layer.cornerRadius = self.bounds.height / 2
@@ -34,5 +35,4 @@ class FilterButton: UIButton {
     func configureTitle(_ text: String) {
         self.setTitle(text, for: .normal)
     }
-
 }

--- a/iOS/Airbnb/AirbnbTests/DateMangerTests.swift
+++ b/iOS/Airbnb/AirbnbTests/DateMangerTests.swift
@@ -1,0 +1,26 @@
+//
+//  DateMangerTests.swift
+//  AirbnbTests
+//
+//  Created by delma on 2020/05/29.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import XCTest
+@testable import Airbnb
+
+class DateMangerTests: XCTestCase {
+
+    var dateManager: DateManager!
+    
+    override func setUp() {
+        dateManager = DateManager()
+    }
+    
+    func testCountOfDays() {
+        let july = dateManager.countOfDays(year: 2020, month: 7)
+        XCTAssertEqual(july, 31)
+        let september = dateManager.countOfDays(year: 2020, month: 9)
+        XCTAssertEqual(september, 30)
+    }
+}


### PR DESCRIPTION
- 날짜 선택시 상단에 선택한 체크인-체크아웃 날짜가 보여지도록 했습니다
- 체크아웃까지 선택한 경우에만 버튼이 활성화되게 했고, 가시적으로 표현하기 위해 버튼의 백그라운드 컬러를 변경되게끔 했습니다
- 초기화버튼을 누른 경우 배열의 모든 요소들을 지우고 컬렉션뷰를 리로드하게 했습니다
- 완료버튼 선택시 숙소 찾는 화면으로 이동하게되는데, 이때 선택한 체크인-아웃 날짜를 담아 보내도록 델리게이트 패턴을 활용했습니다

-----
- 현재 SearchViewController에 중복되는 코드는 인원 선택과 가격선택 기능 구현 하면서 고칠 예정입니다
- CalendarViewController에 계속 날짜를 계산해서 담는데 불필요하게 중복되는 로직인 것 같아, 여기도 뷰랑 모델 분리하면서 변경할 예정입니다! 

![스크린샷 2020-05-30 오후 4 03 35](https://user-images.githubusercontent.com/40784518/83322028-5ea33a00-a28f-11ea-955b-9c511c10334a.png)
![스크린샷 2020-05-30 오후 4 03 41](https://user-images.githubusercontent.com/40784518/83322031-62cf5780-a28f-11ea-940f-9f62e0f401ec.png)
