### PR TITLE
[iOS] 가격 범위 화면 기능 구현

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		78E8E575247D35AF00B758E5 /* PopupHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 78E8E571247D35AF00B758E5 /* PopupHeaderView.xib */; };
 		78E8E576247D35AF00B758E5 /* PopupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E8E572247D35AF00B758E5 /* PopupHeaderView.swift */; };
 		78E8E577247D35AF00B758E5 /* PopupFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 78E8E573247D35AF00B758E5 /* PopupFooterView.xib */; };
+		78F799AB2486376D007D7DEC /* PriceRangeGraphHighlightLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F799AA2486376D007D7DEC /* PriceRangeGraphHighlightLayer.swift */; };
 		D6EB7079E86E0EB83762633F /* Pods_Airbnb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83A1F45877EB89C0FF48E0AC /* Pods_Airbnb.framework */; };
 /* End PBXBuildFile section */
 
@@ -113,6 +114,7 @@
 		78E8E571247D35AF00B758E5 /* PopupHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PopupHeaderView.xib; sourceTree = "<group>"; };
 		78E8E572247D35AF00B758E5 /* PopupHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopupHeaderView.swift; sourceTree = "<group>"; };
 		78E8E573247D35AF00B758E5 /* PopupFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PopupFooterView.xib; sourceTree = "<group>"; };
+		78F799AA2486376D007D7DEC /* PriceRangeGraphHighlightLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceRangeGraphHighlightLayer.swift; sourceTree = "<group>"; };
 		83A1F45877EB89C0FF48E0AC /* Pods_Airbnb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Airbnb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E14DC9E64FE40C2DA9226DDC /* Pods-Airbnb.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Airbnb.release.xcconfig"; path = "Target Support Files/Pods-Airbnb/Pods-Airbnb.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -361,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				78C40E212485293400FA98FD /* PriceRangeGraphView.swift */,
+				78F799AA2486376D007D7DEC /* PriceRangeGraphHighlightLayer.swift */,
 				78C40E23248562B400FA98FD /* PriceRangeSlider.swift */,
 				78C40E252485633700FA98FD /* PriceRangeSliderTrackLayer.swift */,
 				78C40E272485639F00FA98FD /* PriceRangeSliderThumbLayer.swift */,
@@ -551,6 +554,7 @@
 				781FC488247BEE8E0091AB61 /* CountControlButton.swift in Sources */,
 				78262B4E247BDCBE007AAEDA /* GuestSelectionView.swift in Sources */,
 				78C40E222485293400FA98FD /* PriceRangeGraphView.swift in Sources */,
+				78F799AB2486376D007D7DEC /* PriceRangeGraphHighlightLayer.swift in Sources */,
 				78C40E1A24851FF800FA98FD /* PriceRangeViewController.swift in Sources */,
 				78E8E576247D35AF00B758E5 /* PopupHeaderView.swift in Sources */,
 				7872575924750C520050DB66 /* CalendarViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="94f-IF-uk0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ILW-jF-BAl">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -477,32 +477,32 @@
                                         <rect key="frame" x="0.0" y="60" width="373" height="280"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O5V-NQ-0ZM">
-                                                <rect key="frame" x="20" y="30" width="333" height="26.5"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                                <rect key="frame" x="20" y="30" width="333" height="24"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1달러부터 1000달러 이상" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="obF-fN-C1w">
-                                                <rect key="frame" x="20" y="86.5" width="333" height="21"/>
+                                                <rect key="frame" x="20" y="74" width="333" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일박 평균 가격은 100달러" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cFu-aA-pQB">
-                                                <rect key="frame" x="20" y="111.5" width="333" height="17"/>
+                                                <rect key="frame" x="20" y="99" width="333" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uD4-fG-lPW" customClass="PriceRangeGraphView" customModule="Airbnb" customModuleProvider="target">
-                                                <rect key="frame" x="32" y="158.5" width="309" height="60"/>
+                                                <rect key="frame" x="32" y="156" width="309" height="60"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="TOd-iD-4oP"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CdD-uv-QS2">
-                                                <rect key="frame" x="32" y="204.5" width="309" height="28"/>
+                                                <rect key="frame" x="32" y="202" width="309" height="28"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="28" id="z8Z-ue-f6g"/>
@@ -512,12 +512,12 @@
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstItem="CdD-uv-QS2" firstAttribute="leading" secondItem="ohS-gY-iEs" secondAttribute="leading" constant="32" id="09k-Qp-QiG"/>
-                                            <constraint firstItem="obF-fN-C1w" firstAttribute="top" secondItem="O5V-NQ-0ZM" secondAttribute="bottom" constant="30" id="I2p-Nk-yHe"/>
+                                            <constraint firstItem="obF-fN-C1w" firstAttribute="top" secondItem="O5V-NQ-0ZM" secondAttribute="bottom" constant="20" id="I2p-Nk-yHe"/>
                                             <constraint firstItem="uD4-fG-lPW" firstAttribute="leading" secondItem="ohS-gY-iEs" secondAttribute="leading" constant="32" id="IYb-NE-3K7"/>
                                             <constraint firstAttribute="trailing" secondItem="cFu-aA-pQB" secondAttribute="trailing" constant="20" id="WK2-b4-uH9"/>
                                             <constraint firstItem="obF-fN-C1w" firstAttribute="leading" secondItem="ohS-gY-iEs" secondAttribute="leading" constant="20" id="Y2W-rs-Var"/>
                                             <constraint firstItem="O5V-NQ-0ZM" firstAttribute="top" secondItem="ohS-gY-iEs" secondAttribute="top" constant="30" id="ZEC-mK-fex"/>
-                                            <constraint firstItem="uD4-fG-lPW" firstAttribute="top" secondItem="cFu-aA-pQB" secondAttribute="bottom" constant="30" id="dk7-R6-Bn7"/>
+                                            <constraint firstItem="uD4-fG-lPW" firstAttribute="top" secondItem="cFu-aA-pQB" secondAttribute="bottom" constant="40" id="dk7-R6-Bn7"/>
                                             <constraint firstAttribute="trailing" secondItem="CdD-uv-QS2" secondAttribute="trailing" constant="32" id="lEc-ft-g2z"/>
                                             <constraint firstAttribute="trailing" secondItem="uD4-fG-lPW" secondAttribute="trailing" constant="32" id="n51-g4-COS"/>
                                             <constraint firstItem="cFu-aA-pQB" firstAttribute="top" secondItem="obF-fN-C1w" secondAttribute="bottom" constant="4" id="nLy-lw-R5t"/>

--- a/iOS/Airbnb/Airbnb/ViewControllers/PriceRangeViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/PriceRangeViewController.swift
@@ -23,6 +23,7 @@ class PriceRangeViewController: UIViewController {
         super.viewDidLoad()
         
         configureView()
+        configureGraph()
         configureSlider()
     }
     
@@ -36,7 +37,16 @@ class PriceRangeViewController: UIViewController {
         headerView.titleLabel.text = "가격"
     }
     
+    private func configureGraph() {
+        graphView.highlightLayer.priceRangeSlider = slider
+    }
+    
     private func configureSlider() {
         sliderView.addSubview(slider)
+        slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
+    }
+    
+    @objc func sliderValueChanged() {
+        graphView.setNeedsDisplay()
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphHighlightLayer.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphHighlightLayer.swift
@@ -1,0 +1,23 @@
+//
+//  PriceRangeGraphHighlightLayer.swift
+//  Airbnb
+//
+//  Created by jinie on 2020/06/02.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import UIKit
+
+class PriceRangeGraphHighlightLayer: CALayer {
+    
+    override func draw(in ctx: CGContext) {
+        let path = UIBezierPath(rect: bounds)
+        
+        ctx.addPath(path.cgPath)
+        ctx.setFillColor(UIColor(white: 0.9, alpha: 1.0).cgColor)
+        ctx.fillPath()
+        
+        ctx.setFillColor(UIColor(white: 0.7, alpha: 1.0).cgColor)
+        ctx.fill(CGRect(x: 100.0, y: 0.0, width: 100.0, height: bounds.height))
+    }
+}

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphHighlightLayer.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphHighlightLayer.swift
@@ -10,14 +10,21 @@ import UIKit
 
 class PriceRangeGraphHighlightLayer: CALayer {
     
+    weak var priceRangeSlider: PriceRangeSlider?
+    
     override func draw(in ctx: CGContext) {
+        guard let priceRangeSlider = priceRangeSlider else { return }
+        
         let path = UIBezierPath(rect: bounds)
+        let lowerValuePosition = priceRangeSlider.position(of: priceRangeSlider.lowerValue)
+        let upperValuePosition = priceRangeSlider.position(of: priceRangeSlider.upperValue)
+        let highlightedRect = CGRect(x: lowerValuePosition, y: 0.0, width: upperValuePosition - lowerValuePosition, height: bounds.height)
         
         ctx.addPath(path.cgPath)
         ctx.setFillColor(UIColor(white: 0.9, alpha: 1.0).cgColor)
         ctx.fillPath()
         
         ctx.setFillColor(UIColor(white: 0.7, alpha: 1.0).cgColor)
-        ctx.fill(CGRect(x: 100.0, y: 0.0, width: 100.0, height: bounds.height))
+        ctx.fill(highlightedRect)
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphView.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeGraphView.swift
@@ -12,10 +12,17 @@ class PriceRangeGraphView: UIView {
     
     var data: [CGFloat] = [0, 0, 0, 0, 0, 2, 5, 4, 13, 10, 14, 11, 16, 14, 20, 15, 13, 10, 8, 6, 7, 6, 4, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     
+    let highlightLayer = PriceRangeGraphHighlightLayer()
+    
     override func draw(_ rect: CGRect) {
         let path = curvedPath()
-        UIColor(white: 0.7, alpha: 1.0).set()
-        path.fill()
+        let mask = CAShapeLayer()
+        mask.path = path.cgPath
+        
+        layer.addSublayer(highlightLayer)
+        highlightLayer.mask = mask
+        highlightLayer.frame = bounds
+        highlightLayer.setNeedsDisplay()
     }
     
     func curvedPath() -> UIBezierPath {

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -96,10 +96,10 @@ extension PriceRangeSlider {
         
         if lowerThumbLayer.isHighlighted {
             lowerValue += draggedValue
-            lowerValue = max(lowerValue, minimumValue)
+            lowerValue = min(max(lowerValue, minimumValue), upperValue - (thumbWidth / bounds.width))
         } else if upperThumbLayer.isHighlighted {
             upperValue += draggedValue
-            upperValue = min(upperValue, maximumValue)
+            upperValue = min(max(upperValue, lowerValue + (thumbWidth / bounds.width)), maximumValue)
         }
         
         updateLayerFrames()

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -96,8 +96,10 @@ extension PriceRangeSlider {
         
         if lowerThumbLayer.highlighted {
             lowerValue += draggedValue
+            lowerValue = max(lowerValue, minimumValue)
         } else if upperThumbLayer.highlighted {
             upperValue += draggedValue
+            upperValue = min(upperValue, maximumValue)
         }
         
         updateLayerFrames()

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -20,6 +20,7 @@ class PriceRangeSlider: UIControl {
     var maximumValue: CGFloat = 1.0
     var lowerValue: CGFloat = 0.0
     var upperValue: CGFloat = 1.0
+    var previousLocation = CGPoint()
     
     let trackLayer = PriceRangeSliderTrackLayer()
     let lowerThumbLayer = PriceRangeSliderThumbLayer()
@@ -71,5 +72,20 @@ class PriceRangeSlider: UIControl {
     
     func position(of value: CGFloat) -> CGFloat {
         return bounds.width * CGFloat(value)
+    }
+}
+
+extension PriceRangeSlider {
+    
+    override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        previousLocation = touch.location(in: self)
+        
+        if lowerThumbLayer.frame.contains(previousLocation) {
+            lowerThumbLayer.highlighted = true
+        } else if upperThumbLayer.frame.contains(previousLocation) {
+            upperThumbLayer.highlighted = true
+        }
+        
+        return lowerThumbLayer.highlighted || upperThumbLayer.highlighted
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -97,9 +97,11 @@ extension PriceRangeSlider {
         if lowerThumbLayer.isHighlighted {
             lowerValue += draggedValue
             lowerValue = min(max(lowerValue, minimumValue), upperValue - (thumbWidth / bounds.width))
+            lowerThumbLayer.transform = CATransform3DMakeScale(1.2, 1.2, 1.2)
         } else if upperThumbLayer.isHighlighted {
             upperValue += draggedValue
             upperValue = min(max(upperValue, lowerValue + (thumbWidth / bounds.width)), maximumValue)
+            upperThumbLayer.transform = CATransform3DMakeScale(1.2, 1.2, 1.2)
         }
         
         sendActions(for: .valueChanged)
@@ -109,7 +111,12 @@ extension PriceRangeSlider {
     }
     
     override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
-        lowerThumbLayer.isHighlighted = false
-        upperThumbLayer.isHighlighted = false
+        if lowerThumbLayer.isHighlighted {
+            lowerThumbLayer.transform = CATransform3DMakeScale(1.0, 1.0, 1.0)
+            lowerThumbLayer.isHighlighted = false
+        } else if upperThumbLayer.isHighlighted {
+            upperThumbLayer.transform = CATransform3DMakeScale(1.0, 1.0, 1.0)
+            upperThumbLayer.isHighlighted = false
+        }
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -56,7 +56,7 @@ class PriceRangeSlider: UIControl {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         
-        trackLayer.frame = bounds.insetBy(dx: 0.0, dy: 12.5)
+        trackLayer.frame = bounds.insetBy(dx: 0.0, dy: (bounds.height - 3.0) / 2)
         trackLayer.setNeedsDisplay()
         
         let lowerThumbCenter = position(of: lowerValue)

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -102,6 +102,7 @@ extension PriceRangeSlider {
             upperValue = min(max(upperValue, lowerValue + (thumbWidth / bounds.width)), maximumValue)
         }
         
+        sendActions(for: .valueChanged)
         updateLayerFrames()
         
         return true

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -88,4 +88,20 @@ extension PriceRangeSlider {
         
         return lowerThumbLayer.highlighted || upperThumbLayer.highlighted
     }
+    
+    override func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        let currentLocation = touch.location(in: self)
+        let draggedValue = (currentLocation.x - previousLocation.x) / bounds.width
+        previousLocation = currentLocation
+        
+        if lowerThumbLayer.highlighted {
+            lowerValue += draggedValue
+        } else if upperThumbLayer.highlighted {
+            upperValue += draggedValue
+        }
+        
+        updateLayerFrames()
+        
+        return true
+    }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSlider.swift
@@ -81,12 +81,12 @@ extension PriceRangeSlider {
         previousLocation = touch.location(in: self)
         
         if lowerThumbLayer.frame.contains(previousLocation) {
-            lowerThumbLayer.highlighted = true
+            lowerThumbLayer.isHighlighted = true
         } else if upperThumbLayer.frame.contains(previousLocation) {
-            upperThumbLayer.highlighted = true
+            upperThumbLayer.isHighlighted = true
         }
         
-        return lowerThumbLayer.highlighted || upperThumbLayer.highlighted
+        return lowerThumbLayer.isHighlighted || upperThumbLayer.isHighlighted
     }
     
     override func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
@@ -94,10 +94,10 @@ extension PriceRangeSlider {
         let draggedValue = (currentLocation.x - previousLocation.x) / bounds.width
         previousLocation = currentLocation
         
-        if lowerThumbLayer.highlighted {
+        if lowerThumbLayer.isHighlighted {
             lowerValue += draggedValue
             lowerValue = max(lowerValue, minimumValue)
-        } else if upperThumbLayer.highlighted {
+        } else if upperThumbLayer.isHighlighted {
             upperValue += draggedValue
             upperValue = min(upperValue, maximumValue)
         }
@@ -105,5 +105,10 @@ extension PriceRangeSlider {
         updateLayerFrames()
         
         return true
+    }
+    
+    override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+        lowerThumbLayer.isHighlighted = false
+        upperThumbLayer.isHighlighted = false
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSliderThumbLayer.swift
+++ b/iOS/Airbnb/Airbnb/Views/PriceRangeView/PriceRangeSliderThumbLayer.swift
@@ -11,7 +11,7 @@ import UIKit
 class PriceRangeSliderThumbLayer: CALayer {
 
     weak var priceRangeSlider: PriceRangeSlider?
-    var highlighted = false
+    var isHighlighted = false
     
     override func draw(in ctx: CGContext) {
         guard let priceRangeSlider = priceRangeSlider else { return }


### PR DESCRIPTION
- 슬라이더 버튼이 범위 내에서만 드래그 가능하도록 구현
- 두 슬라이더 버튼이 서로 겹치거나 지나치지 않도록 구현
- 설정한 가격 범위에 따라 그래프에 강조 표시
- 슬라이더 버튼 드래그 시 버튼의 크기를 변환하는 transform 적용

![Price Range](https://user-images.githubusercontent.com/58341840/83544776-6423ad00-a539-11ea-9b21-afeda1271575.gif)