### PR TITLE
[iOS] 즐겨찾기 화면 구성 및 즐겨찾는 목록 보여줌 

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		3054CF6624813F3F0097775B /* DateMangerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3054CF6524813F3F0097775B /* DateMangerTests.swift */; };
 		305B1B842482347000836302 /* PassSelectedConditionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305B1B832482347000836302 /* PassSelectedConditionDelegate.swift */; };
 		306FD62A247D402A00A65DB0 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306FD629247D402A00A65DB0 /* MainViewController.swift */; };
+		30729FD724893CEF00A61092 /* BookMarkedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30729FD624893CEF00A61092 /* BookMarkedViewController.swift */; };
+		30729FD924893D9C00A61092 /* BookMarkedCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30729FD824893D9C00A61092 /* BookMarkedCollectionViewDataSource.swift */; };
 		30A5C16624852D3900D8D2D9 /* NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A5C16524852D3900D8D2D9 /* NetworkDispatcher.swift */; };
 		30A5C1682485412600D8D2D9 /* ExtendedSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A5C1672485412600D8D2D9 /* ExtendedSession.swift */; };
 		30AEC503247FA1A300EB7413 /* AccommodationRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AEC502247FA1A300EB7413 /* AccommodationRequests.swift */; };
@@ -76,6 +78,8 @@
 		3054CF6524813F3F0097775B /* DateMangerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateMangerTests.swift; sourceTree = "<group>"; };
 		305B1B832482347000836302 /* PassSelectedConditionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassSelectedConditionDelegate.swift; sourceTree = "<group>"; };
 		306FD629247D402A00A65DB0 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		30729FD624893CEF00A61092 /* BookMarkedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BookMarkedViewController.swift; path = Airbnb/ViewControllers/BookMarkedViewController.swift; sourceTree = SOURCE_ROOT; };
+		30729FD824893D9C00A61092 /* BookMarkedCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookMarkedCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		30A5C16524852D3900D8D2D9 /* NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDispatcher.swift; sourceTree = "<group>"; };
 		30A5C1672485412600D8D2D9 /* ExtendedSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedSession.swift; sourceTree = "<group>"; };
 		30AEC502247FA1A300EB7413 /* AccommodationRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccommodationRequests.swift; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 			isa = PBXGroup;
 			children = (
 				30B2E9252473F367002FB866 /* AccommodationSearchCollectionViewDataSource.swift */,
+				30729FD824893D9C00A61092 /* BookMarkedCollectionViewDataSource.swift */,
 			);
 			path = DataSources;
 			sourceTree = "<group>";
@@ -304,6 +309,7 @@
 				306FD629247D402A00A65DB0 /* MainViewController.swift */,
 				30B2E9232473F2C6002FB866 /* SearchViewController.swift */,
 				7872575824750C520050DB66 /* CalendarViewController.swift */,
+				30729FD624893CEF00A61092 /* BookMarkedViewController.swift */,
 				78262B4A247BDB88007AAEDA /* GuestViewController.swift */,
 				78C40E1924851FF800FA98FD /* PriceRangeViewController.swift */,
 			);
@@ -589,6 +595,7 @@
 				305B1B842482347000836302 /* PassSelectedConditionDelegate.swift in Sources */,
 				78C40E282485639F00FA98FD /* PriceRangeSliderThumbLayer.swift in Sources */,
 				30B05656247E7AAB005AD8BB /* Request.swift in Sources */,
+				30729FD724893CEF00A61092 /* BookMarkedViewController.swift in Sources */,
 				78802ACB2473A3C200A901E2 /* SceneDelegate.swift in Sources */,
 				30B2E928247401EB002FB866 /* SearchTextField.swift in Sources */,
 				30B89492247FD57A00DFF944 /* AccommodationListMock.swift in Sources */,
@@ -610,6 +617,7 @@
 				30B2E9202473D228002FB866 /* Accommodation.swift in Sources */,
 				30DE2A4A2488C55A00867973 /* NetworkError.swift in Sources */,
 				30A5C16624852D3900D8D2D9 /* NetworkDispatcher.swift in Sources */,
+				30729FD924893D9C00A61092 /* BookMarkedCollectionViewDataSource.swift in Sources */,
 				306FD62A247D402A00A65DB0 /* MainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -133,14 +133,46 @@
         <!--즐겨찾기-->
         <scene sceneID="c8E-3v-PhP">
             <objects>
-                <viewController id="pNS-Jv-GI3" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BookMarkedViewController" id="pNS-Jv-GI3" customClass="BookMarkedViewController" customModule="Airbnb" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="N3w-Mr-jeN">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="awc-jQ-I6f" customClass="AccommodationSearchCollectionView" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44" width="414" height="769"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ThT-PT-jYu">
+                                    <size key="itemSize" width="411" height="240"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AccommodationSearchCollectionViewCell" id="fQb-y7-ODC" customClass="AccommodationSearchCollectionViewCell" customModule="Airbnb" customModuleProvider="target">
+                                        <rect key="frame" x="8" y="0.0" width="398" height="251"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="LER-hI-DpF">
+                                            <rect key="frame" x="0.0" y="0.0" width="398" height="251"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="398" height="251"/>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="awc-jQ-I6f" firstAttribute="leading" secondItem="BcZ-ba-CnP" secondAttribute="leading" id="0Rz-oF-9ty"/>
+                            <constraint firstItem="awc-jQ-I6f" firstAttribute="top" secondItem="BcZ-ba-CnP" secondAttribute="top" id="PYE-7K-7Ue"/>
+                            <constraint firstItem="BcZ-ba-CnP" firstAttribute="bottom" secondItem="awc-jQ-I6f" secondAttribute="bottom" id="c6e-w4-G2l"/>
+                            <constraint firstItem="BcZ-ba-CnP" firstAttribute="trailing" secondItem="awc-jQ-I6f" secondAttribute="trailing" id="kUi-Pl-K9j"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="BcZ-ba-CnP"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="즐겨찾기" image="heart.fill" catalog="system" selectedImage="heart.fill" id="dRP-hW-Het"/>
+                    <connections>
+                        <outlet property="bookMarkedCollectionView" destination="awc-jQ-I6f" id="QRR-24-m7j"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bOp-Ux-cUA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOS/Airbnb/Airbnb/DataSources/BookMarkedCollectionViewDataSource.swift
+++ b/iOS/Airbnb/Airbnb/DataSources/BookMarkedCollectionViewDataSource.swift
@@ -6,4 +6,23 @@
 //  Copyright © 2020 jinie. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+class BookMarkedCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+    
+    private var accommodations: [Accommodation]
+    
+    init(accommodations: [Accommodation]) {
+        self.accommodations = accommodations
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return accommodations.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "AccommodationSearchCollectionViewCell", for: indexPath) as! AccommodationSearchCollectionViewCell
+        cell.configureData(accommodations[indexPath.row])
+        return cell
+    }
+}

--- a/iOS/Airbnb/Airbnb/DataSources/BookMarkedCollectionViewDataSource.swift
+++ b/iOS/Airbnb/Airbnb/DataSources/BookMarkedCollectionViewDataSource.swift
@@ -1,0 +1,9 @@
+//
+//  BookMarkedCollectionViewDataSource.swift
+//  Airbnb
+//
+//  Created by delma on 2020/06/04.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Airbnb/Airbnb/Network/EndPoints.swift
+++ b/iOS/Airbnb/Airbnb/Network/EndPoints.swift
@@ -15,6 +15,7 @@ enum EndPoints {
     static let bookings = "bookings"
     static let map = "map"
     static let priceGraph = "price-graph"
+    static let bookmarks = "bookmarks"
 }
 
 enum QueryParameters: CustomStringConvertible {

--- a/iOS/Airbnb/Airbnb/Network/Requests/AccommodationRequests.swift
+++ b/iOS/Airbnb/Airbnb/Network/Requests/AccommodationRequests.swift
@@ -13,12 +13,14 @@ enum AccommodationRequests<T> {
     case detail
     case list
     case liked
+    case likedList
     
     var request: T {
         switch self {
         case .detail: return AccommodationRequest() as! T
         case .list: return AccommodationListRequest() as! T
-        case .liked: return LikedAccommodationListRequest() as! T
+        case .liked: return AccommodationLikedRequest() as! T
+        case .likedList: return AccommodationLikedListRequest() as! T
         }
     }
 }
@@ -62,9 +64,17 @@ final class AccommodationListRequest: AccommodationRequest, Queryable {
     }
 }
 
-final class LikedAccommodationListRequest: AccommodationRequest {
+final class AccommodationLikedRequest: AccommodationRequest {
     override var method: HTTPMethod {
         get { return .PATCH }
         set { super.method = newValue }
     }
 }
+
+final class AccommodationLikedListRequest: AccommodationRequest {
+    override var path: String {
+        get { return EndPoints.defaultURL + EndPoints.listings + "/" + EndPoints.bookmarks }
+        set { super.path = newValue }
+    }
+}
+

--- a/iOS/Airbnb/Airbnb/ViewControllers/BookMarkedViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/BookMarkedViewController.swift
@@ -1,0 +1,50 @@
+//
+//  BookMarkedViewController.swift
+//  Airbnb
+//
+//  Created by delma on 2020/06/04.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import UIKit
+import Alamofire
+
+class BookMarkedViewController: UIViewController {
+    
+    @IBOutlet weak var bookMarkedCollectionView: AccommodationSearchCollectionView!
+    
+    private var bookMarkedDataSource: BookMarkedCollectionViewDataSource!
+    private var accommodationViewModel: AccommodationListViewModel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        collectionViewConfigure()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        requestBookMarkedAccommodations()
+        
+    }
+    
+    private func collectionViewConfigure() {
+        bookMarkedCollectionView.register(UINib(nibName: "AccommodationSearchCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "AccommodationSearchCollectionViewCell")
+        let layout = UICollectionViewFlowLayout()
+        layout.itemSize = CGSize(width: self.view.frame.width - 40, height: self.view.frame.height / 3)
+        layout.scrollDirection = .vertical
+        bookMarkedCollectionView.collectionViewLayout = layout
+        bookMarkedCollectionView.showsVerticalScrollIndicator = false
+    }
+    
+    private func requestBookMarkedAccommodations() {
+        let request = AccommodationRequests<AccommodationLikedListRequest>.likedList.request.asURLRequest()
+        AccommodationUseCase(request: request, networkDispatcher: AF).perform(dataType: [Accommodation].self) { accommodation in
+            self.accommodationViewModel = AccommodationListViewModel(accommodation: accommodation as! [Accommodation], handler: { accommodations in
+                DispatchQueue.main.async {
+                    self.bookMarkedDataSource = BookMarkedCollectionViewDataSource(accommodations: accommodations)
+                    self.bookMarkedCollectionView.dataSource = self.bookMarkedDataSource
+                    self.bookMarkedCollectionView.reloadData()
+                }
+            })
+        }
+    }
+}

--- a/iOS/Airbnb/Airbnb/ViewControllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/ViewControllers/SearchViewController.swift
@@ -84,7 +84,7 @@ class SearchViewController: UIViewController {
     
     @objc private func requestAccommodationBookmark(_ notification: Notification) {
         guard let id = notification.userInfo?["id"] as? Int else { return }
-        let likeRequest = AccommodationRequests<LikedAccommodationListRequest>.liked.request
+        let likeRequest = AccommodationRequests<AccommodationLikedRequest>.liked.request
         likeRequest.append(id: id)
         let request = likeRequest.asURLRequest()
         AccommodationUseCase(request: request, networkDispatcher: AF).perform(id: id) { result in

--- a/iOS/Airbnb/Airbnb/Views/SearchView/AccommodationSearchCollectionViewCell.xib
+++ b/iOS/Airbnb/Airbnb/Views/SearchView/AccommodationSearchCollectionViewCell.xib
@@ -61,7 +61,7 @@
                                 <state key="selected" image="heart.fill" catalog="system"/>
                                 <state key="highlighted" image="heart.fill" catalog="system"/>
                                 <connections>
-                                    <action selector="bookmark:" destination="gTV-IL-0wX" eventType="touchUpInside" id="UfJ-YT-4oS"/>
+                                    <action selector="bookmark:" destination="gTV-IL-0wX" eventType="touchUpInside" id="3BR-Al-qcb"/>
                                 </connections>
                             </button>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="a2i-RE-zCy">


### PR DESCRIPTION
- 숙소 찾기 화면에서 사용했던 셀 재사용
- 라이프사이클을 이용해 즐겨찾기 화면 띄워질때마다 목록 재요청해서 즉각적인 변동사항 반영함 

![스크린샷 2020-06-05 오전 11 23 31](https://user-images.githubusercontent.com/40784518/83830001-22545b80-a71f-11ea-9835-8ae885c0aa66.png)

